### PR TITLE
Better printing of empty results

### DIFF
--- a/analyze.Rmd
+++ b/analyze.Rmd
@@ -292,6 +292,10 @@ ahref <- function(href, text){
   sprintf('<a href="%s">%s</a>', href, text)
 }
 mytab <- function(DT){
+  if (!nrow(DT)) {
+    cat("Empty table: nothing to print.\n")
+    return(invisible())
+  }
   copied <- data.table(DT)
   if("CRAN" %in% names(copied)){
     copied[, CRAN := ahref(sprintf(


### PR DESCRIPTION
Saw this confusing blob of text:

![image](https://github.com/user-attachments/assets/ae4a0446-4d01-4968-87ee-15e0eddbbf84)

Took a while to realize I'm looking at kludged column names of an empty table.