### PR TITLE
Use NO_COLOR approach to suppress color

### DIFF
--- a/myStatus.R
+++ b/myStatus.R
@@ -1,6 +1,6 @@
 get_check_cmd <- function(pkg.tar.gz){
   paste(
-    "TERM=dumb",
+    "NO_COLOR=true", # for tinytest
     "_R_CHECK_TESTS_NLINES_=0",
     "_R_CHECK_FORCE_SUGGESTS_=0",
     R.home("bin/R"),


### PR DESCRIPTION
This is (or will be?) the approach in {tinytest} as of a few days ago:

https://github.com/markvanderloo/tinytest/commit/c3ddc5b1a4500d2be210a374e6dc025f6cdbaa14

I like that it's more obvious/readable, and could also be used by other packages besides {tinytest}.

Possibly this PR could wait for a {tinytest} release to CRAN, but I also don't think it makes a big difference to just go ahead and merge now in anticipation.

Another approach is to leave `TERM=dumb` set with a TODO to remove it eventually.